### PR TITLE
Fix Indexing Notebook Example

### DIFF
--- a/examples/tctrepro-lastmile-indexing.ipynb
+++ b/examples/tctrepro-lastmile-indexing.ipynb
@@ -50,7 +50,7 @@
     "index_pipeline = (\n",
     "    TctColBert('castorini/tct_colbert-v2-msmarco') >>\n",
     "    NumpyIndex('indices/castorini__tct_colbert-v2-msmarco.np'))\n",
-    "index_pipeline.index(dataset)"
+    "index_pipeline.index(dataset.get_corpus_iter())"
    ]
   },
   {
@@ -64,7 +64,7 @@
     "index_pipeline = (\n",
     "    TctColBert('castorini/tct_colbert-v2-hn-msmarco') >>\n",
     "    NumpyIndex('indices/castorini__tct_colbert-v2-hn-msmarco.np'))\n",
-    "index_pipeline.index(dataset)"
+    "index_pipeline.index(dataset.get_corpus_iter())"
    ]
   },
   {
@@ -78,7 +78,7 @@
     "index_pipeline = (\n",
     "    TctColBert('castorini/tct_colbert-v2-hnp-msmarco') >>\n",
     "    NumpyIndex('indices/castorini__tct_colbert-v2-hnp-msmarco.np'))\n",
-    "index_pipeline.index(dataset)"
+    "index_pipeline.index(dataset.get_corpus_iter())"
    ]
   },
   {


### PR DESCRIPTION
The indexing example notebook has the following error when run:

```
TypeError: 'IRDSDataset' object is not iterable

[<ipython-input-5-c0bb7af1bd65>](https://localhost:8080/#) in <module>
      3     TctColBert('castorini/tct_colbert-v2-msmarco') >>
      4     NumpyIndex('indices/castorini__tct_colbert-v2-msmarco.np'))
----> 5 index_pipeline.index(dataset)

...
```

as it tries to iterate over the IRDSDataset object rather than the dataset inside. 

Update the examples to call the `get_corpus_iter` method on the dataset when indexing so that the example runs.
