### PR TITLE
Add Lightning IR support for cross-encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ if you want to use the BGE-M3 encoder with `pyterrier_dr`, you can install the p
 pip install pyterrier-dr[bgem3]
 ```
 
+If you want to use `lightning-ir` models with `pyterrier_dr`, you can install the package with the `lightning-ir` dependency:
+
+```bash
+pip install pyterrier-dr[lightning-ir]
+```
+
 ---
 You'll also need to install FAISS.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = {file = ["requirements.txt"]}
 bgem3 = [
   "FlagEmbedding",
 ]
+lightning-ir = [
+  "lightning-ir",
+]
 
 [tool.setuptools.packages.find]
 exclude = ["tests"]

--- a/pyterrier_dr/__init__.py
+++ b/pyterrier_dr/__init__.py
@@ -8,7 +8,7 @@ from pyterrier_dr.hgf_models import HgfBiEncoder, TasB, RetroMAE
 from pyterrier_dr.sbert_models import SBertBiEncoder, Ance, Query2Query, GTR, E5
 from pyterrier_dr.tctcolbert_model import TctColBert
 from pyterrier_dr.electra import ElectraScorer
-from pyterrier_dr.webis_mono_electra import WebisElectraScorer
+from pyterrier_dr.lightning_ir_mono import LightningIRMonoScorer
 from pyterrier_dr.bge_m3 import BGEM3, BGEM3QueryEncoder, BGEM3DocEncoder
 from pyterrier_dr.cde import CDE, CDECache
 from pyterrier_dr.prf import AveragePrf, VectorPrf
@@ -17,5 +17,5 @@ from pyterrier_dr._mmr import MmrScorer
 
 __all__ = ["FlexIndex", "DocnoFile", "NilIndex", "NumpyIndex", "RankedLists", "FaissFlat", "FaissHnsw", "MemIndex", "TorchIndex",
            "BiEncoder", "BiQueryEncoder", "BiDocEncoder", "BiScorer", "HgfBiEncoder", "TasB", "RetroMAE", "SBertBiEncoder", "Ance",
-           "Query2Query", "GTR", "E5", "TctColBert", "ElectraScorer", "WebisElectraScorer", "BGEM3", "BGEM3QueryEncoder", "BGEM3DocEncoder", "CDE", "CDECache",
+           "Query2Query", "GTR", "E5", "TctColBert", "ElectraScorer", "LightningIRMonoScorer", "BGEM3", "BGEM3QueryEncoder", "BGEM3DocEncoder", "CDE", "CDECache",
            "SimFn", "infer_device", "AveragePrf", "VectorPrf", "ILS", "ils", "MmrScorer"]

--- a/pyterrier_dr/__init__.py
+++ b/pyterrier_dr/__init__.py
@@ -8,6 +8,7 @@ from pyterrier_dr.hgf_models import HgfBiEncoder, TasB, RetroMAE
 from pyterrier_dr.sbert_models import SBertBiEncoder, Ance, Query2Query, GTR, E5
 from pyterrier_dr.tctcolbert_model import TctColBert
 from pyterrier_dr.electra import ElectraScorer
+from pyterrier_dr.webis_mono_electra import WebisElectraScorer
 from pyterrier_dr.bge_m3 import BGEM3, BGEM3QueryEncoder, BGEM3DocEncoder
 from pyterrier_dr.cde import CDE, CDECache
 from pyterrier_dr.prf import AveragePrf, VectorPrf
@@ -16,5 +17,5 @@ from pyterrier_dr._mmr import MmrScorer
 
 __all__ = ["FlexIndex", "DocnoFile", "NilIndex", "NumpyIndex", "RankedLists", "FaissFlat", "FaissHnsw", "MemIndex", "TorchIndex",
            "BiEncoder", "BiQueryEncoder", "BiDocEncoder", "BiScorer", "HgfBiEncoder", "TasB", "RetroMAE", "SBertBiEncoder", "Ance",
-           "Query2Query", "GTR", "E5", "TctColBert", "ElectraScorer", "BGEM3", "BGEM3QueryEncoder", "BGEM3DocEncoder", "CDE", "CDECache",
+           "Query2Query", "GTR", "E5", "TctColBert", "ElectraScorer", "WebisElectraScorer", "BGEM3", "BGEM3QueryEncoder", "BGEM3DocEncoder", "CDE", "CDECache",
            "SimFn", "infer_device", "AveragePrf", "VectorPrf", "ILS", "ils", "MmrScorer"]

--- a/pyterrier_dr/lightning_ir_mono.py
+++ b/pyterrier_dr/lightning_ir_mono.py
@@ -11,7 +11,7 @@ except ImportError:
     pass
 
 
-class WebisElectraScorer(pt.Transformer):
+class LightningIRMonoScorer(pt.Transformer):
     def __init__(self,
                  model_name='webis/monoelectra-base',
                  batch_size=16,
@@ -21,7 +21,7 @@ class WebisElectraScorer(pt.Transformer):
                  query_length=32,
                  doc_length=512):
         if not LIGHTNING_IR_AVAILIBLE:
-            raise ImportError("lightning_ir is required for WebisElectraScorer. Please install it via 'pip install lightning-ir'")
+            raise ImportError("lightning_ir is required for LightningIRMonoScorer. Please install it via 'pip install lightning-ir'")
         self.model_name = model_name
         self.batch_size = batch_size
         self.text_field = text_field

--- a/pyterrier_dr/webis_mono_electra.py
+++ b/pyterrier_dr/webis_mono_electra.py
@@ -1,0 +1,61 @@
+import numpy as np
+import more_itertools
+import torch
+import pyterrier as pt
+
+LIGHTNING_IR_AVAILIBLE = False
+try:
+    import lightning_ir as L
+    LIGHTNING_IR_AVAILIBLE = True
+except ImportError:
+    pass
+
+
+class WebisElectraScorer(pt.Transformer):
+    def __init__(self,
+                 model_name='webis/monoelectra-base',
+                 batch_size=16,
+                 text_field='text',
+                 verbose=True,
+                 device=None,
+                 query_length=32,
+                 doc_length=512):
+        if not LIGHTNING_IR_AVAILIBLE:
+            raise ImportError("lightning_ir is required for WebisElectraScorer. Please install it via 'pip install lightning-ir'")
+        self.model_name = model_name
+        self.batch_size = batch_size
+        self.text_field = text_field
+        self.verbose = verbose
+        if device is None:
+            device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        self.device = torch.device(device)
+        self.tokenizer = L.cross_encoder.cross_encoder_tokenizer.CrossEncoderTokenizer.from_pretrained(model_name,
+                                                                                                       query_length=query_length,
+                                                                                                       doc_length=doc_length)
+        self.model = L.models.cross_encoders.mono.MonoModel.from_pretrained(model_name).eval().to(self.device)
+
+    def transform(self, inp):
+        scores = []
+        it = inp[['query', self.text_field]].itertuples(index=False)
+        if self.verbose:
+            it = pt.tqdm(it, total=len(inp), unit='record', desc='ELECTRA scoring')
+        with torch.no_grad():
+            for chunk in more_itertools.chunked(it, self.batch_size):
+                queries, texts = map(list, zip(*chunk))
+                inps = self.tokenizer.tokenize(queries=queries,
+                                               docs=texts,
+                                               padding=True,
+                                               truncation=True,
+                                               return_tensors='pt'
+                                               )["encoding"].to(self.device)
+                with torch.inference_mode():
+                    output = self.model.forward(inps).scores
+                scores.append(output.cpu().detach().numpy())
+        if not scores:
+            scores = np.empty(shape=(0, 0))
+        else:
+            scores = np.concatenate(scores, axis=0)
+        res = inp.assign(score=scores)
+        pt.model.add_ranks(res)
+        res = res.sort_values(['qid', 'rank'])
+        return res

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -214,9 +214,9 @@ class TestModels(unittest.TestCase):
         self._test_bgem3_multi(bgem3.doc_multi_encoder(), test_doc_multivec_encoder=True)
 
     @unittest.skipIf(not LIGHTNING_IR_AVAILIBLE, "lightning_ir is not installed")
-    def test_webis_mono_electra(self):
-        from pyterrier_dr import WebisElectraScorer
-        self._base_crossencoder_test(WebisElectraScorer(
+    def test_lightning_ir_mono_electra(self):
+        from pyterrier_dr import LightningIRMonoScorer
+        self._base_crossencoder_test(LightningIRMonoScorer(
                             model_name='webis/monoelectra-base'
                         ))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,13 @@ import pandas as pd
 import pyterrier as pt
 from pyterrier_dr import FlexIndex
 
+LIGHTNING_IR_AVAILIBLE = False
+try:
+    import lightning_ir
+    LIGHTNING_IR_AVAILIBLE = True
+except ImportError:
+    pass
+
 
 class TestModels(unittest.TestCase):
 
@@ -103,6 +110,26 @@ class TestModels(unittest.TestCase):
                     self.assertTrue('docno' in retr_res.columns)
                     self.assertTrue('score' in retr_res.columns)
                     self.assertTrue('rank' in retr_res.columns)
+
+    def _base_crossencoder_test(self, model):
+        dataset = pt.get_dataset('irds:vaswani')
+        topics = dataset.get_topics().head(10)
+
+        docs = list(itertools.islice(pt.get_dataset('irds:vaswani').get_corpus_iter(), 50))
+        docs_df = pd.DataFrame(docs)
+
+        with self.subTest('scorer_qtext_dtext'):
+            res_qtext_dtext = topics.head(2).merge(docs_df, how='cross')
+            scored_res_qtext_dtext = model(res_qtext_dtext)
+            self.assertTrue('score' in scored_res_qtext_dtext.columns)
+            self.assertTrue('rank' in scored_res_qtext_dtext.columns)
+            self.assertTrue(all(c in scored_res_qtext_dtext.columns for c in res_qtext_dtext.columns))
+
+        with self.subTest('scorer empty'):
+            enc_res_empty = model(pd.DataFrame(columns=['qid', 'query', 'docno', 'text']))
+            self.assertEqual(len(enc_res_empty), 0)
+            self.assertTrue('score' in enc_res_empty.columns)
+            self.assertTrue('rank' in enc_res_empty.columns)
     
     def _test_bgem3_multi(self, model, test_query_multivec_encoder=False, test_doc_multivec_encoder=False):
         dataset = pt.get_dataset('irds:vaswani')
@@ -179,12 +206,19 @@ class TestModels(unittest.TestCase):
         from pyterrier_dr import BGEM3
         # create BGEM3 instance
         bgem3 = BGEM3(max_length=1024)
-        
+
         self._base_test(bgem3.query_multi_encoder(), test_doc_encoder=False, test_scorer=False, test_indexer=False, test_retriever=False)
         self._base_test(bgem3.doc_multi_encoder(), test_query_encoder=False, test_scorer=False, test_indexer=False, test_retriever=False)
 
         self._test_bgem3_multi(bgem3.query_multi_encoder(), test_query_multivec_encoder=True)
         self._test_bgem3_multi(bgem3.doc_multi_encoder(), test_doc_multivec_encoder=True)
+
+    @unittest.skipIf(not LIGHTNING_IR_AVAILIBLE, "lightning_ir is not installed")
+    def test_webis_mono_electra(self):
+        from pyterrier_dr import WebisElectraScorer
+        self._base_crossencoder_test(WebisElectraScorer(
+                            model_name='webis/monoelectra-base'
+                        ))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds support for the lightning-ir mono models. The model is composed dynamically, and at this stage, it is easier to induce a new optional dependency than to derive their class from scratch. The object LightningIRMonoScorer will raise an import error if instantiation is attempted without the necessary package.

New test infrastructure has been added for testing cross-encoders, which is similar to the scorer component of the current base test, but does not test for situations where vectors are supplied. 