### PR TITLE
add JPQ documentation

### DIFF
--- a/pyterrier_dr/__init__.py
+++ b/pyterrier_dr/__init__.py
@@ -19,6 +19,7 @@ from pyterrier_dr.prf import AveragePrf, VectorPrf
 from pyterrier_dr._ils import ILS, ils
 from pyterrier_dr._mmr import MmrScorer
 from pyterrier_dr.jina import JinaEmbedder
+from pyterrier_dr.jpq import JPQTrainer, JPQIndex
 
 __all__ = ["FlexIndex", "DocnoFile", "NilIndex", "NumpyIndex", "RankedLists", "FaissFlat", "FaissHnsw", "MemIndex", "TorchIndex",
            "BiEncoder", "BiQueryEncoder", "BiDocEncoder", "BiScorer", "HgfBiEncoder", "TasB", "RetroMAE", "SBertBiEncoder", "Ance",
@@ -27,4 +28,6 @@ __all__ = ["FlexIndex", "DocnoFile", "NilIndex", "NumpyIndex", "RankedLists", "F
            "LionLlamaDense",
            "Dragon",
            "RepLLama",
+           "JPQTrainer",
+           "JPQIndex",
            "SimFn", "infer_device", "AveragePrf", "VectorPrf", "ILS", "ils", "MmrScorer", "JinaEmbedder"]

--- a/pyterrier_dr/jpq/index.py
+++ b/pyterrier_dr/jpq/index.py
@@ -36,8 +36,19 @@ class Metadata:
         with open(path, 'w', encoding='utf-8') as f:
             json.dump(asdict(self), f)
 
-            
+
 class JPQIndex(pt.Artifact):
+    """Joint Product Quantization index.
+
+    Use :meth:`retriever_pq` to get a PQ retriever.
+
+    Args:
+        path (str | Path): Index path.
+    
+    Attributes:
+        index_path (Path): Index path.
+
+    """
 
     ARTIFACT_TYPE = 'dense_index'
     ARTIFACT_FORMAT = 'jpq'
@@ -61,18 +72,21 @@ class JPQIndex(pt.Artifact):
 
     @property
     def meta(self) -> Metadata:
+        """Meta data for this JPQ index."""
         if self._meta is None:
             self._meta = Metadata.load(self.index_path / JPQIndex._META_FN)
         return self._meta # type: ignore
 
     @property
     def docnos(self) -> Lookup:
+        """Docno lookup."""
         if self._docnos is None:
             self._docnos = Lookup(self.index_path / JPQIndex._DOCNOS_FN)
         return self._docnos
 
     @property
     def codes(self) -> np.ndarray:
+        """PQ code book."""
         if self._codes is None:
             shape = (self.meta.doc_count, self.meta.M)
             dtype = code_type_from_Ks(self.meta.Ks)
@@ -81,6 +95,13 @@ class JPQIndex(pt.Artifact):
 
     @property
     def dvecs(self) -> np.ndarray:
+        """PQ centroids with shape [M, Ks, dsub].
+        
+        Note:
+            M -> numer of splits
+            Ks -> number of centroids per split
+            dsub -> dimension of subvector
+        """
         if self._dvecs is None:
             shape = (self.meta.M, self.meta.Ks, self.meta.dsub)
             self._dvecs = np.memmap(self.index_path / JPQIndex._SUBVECS_FN, mode="r", dtype=np.float32, shape=shape)
@@ -88,6 +109,7 @@ class JPQIndex(pt.Artifact):
     
     @property
     def opq(self) -> np.ndarray | None:
+        """Optional OPQ rotation matrix. None if OPQ is disabled."""
         if not self.meta.opq:
             return None
         if self._opq is None:
@@ -167,19 +189,19 @@ class JPQIndex(pt.Artifact):
         source_index: "JPQIndex",
         target_index: FlexIndex,
         path: str,
-        batch_size: int = 2**16,
+        batch_size: int = 8192,
         mode: IndexingMode = IndexingMode.create,
     ) -> "JPQIndex":
-        """Build a new JPQ index which quantizes vectors from `target_index` using learned parameters of `source_index`.
+        """Return a :class:`JPQIndex` that quantizes `target_index` using learned centroids in `source_index`.
 
         Args:
-            source_index (JPQIndex): A learned JPQ index.
+            source_index (JPQIndex): An existing :class:`JPQIndex`.
             target_index (FlexIndex): Target index with document vectors to be quantized.
-            path (str): Path to save the resulting JPQ index.
-            batch_size (int, optional): Batch size to iterate over the corpus of `target_index`. Defaults to 2**16.
+            path (str): Path to save the resulting :class:`JPQIndex`.
+            batch_size (int, optional): Batch size to iterate over the corpus of ``target_index``. Defaults to 8192.
+            mode (IndexingMode, optional): How to handle an existing index path.
+                Use :attr:`IndexingMode.overwrite` to allow overwriting. Defaults to :attr:`IndexingMode.create`.
 
-        Returns:
-            JPQIndex: The resulting zero-shot JPQ index.
         """
         opq = source_index.opq
         centroids = source_index.dvecs
@@ -224,10 +246,34 @@ class JPQIndex(pt.Artifact):
             yield docdict
 
     def retriever_pq(self, topk: int = 1000) -> "JPQRetrieverPQ":
+        """Return a PQ retriever.
+
+        Args:
+            topk (int, optional): Number of documents to return per query. Defaults to 1000.
+
+        """
         return JPQRetrieverPQ(self.docnos, self.codes, self.dvecs, topk=topk, name="JPQ-PQ", opq = self.opq)
 
     def retriever_flat(self, topk: int = 1000, gpu : bool =False) -> "JPQRetrieverFlat":
+        """Return a flat inner-product retriever (:class:`JPQRetrieverFlat`) over reconstructed vectors.
+
+        Args:
+            topk (int, optional): Number of documents to return per query. Defaults to 1000.
+            gpu (bool, optional): Whether to load the flat index into GPU.
+
+        """
         return JPQRetrieverFlat(self.docnos, self.codes, self.dvecs, topk=topk, name="JPQ-Flat", opq = self.opq, gpu=gpu)
 
     def retriever_prune(self, topk: int = 1000, ub_inflation: float =1.) -> "JPQRetrieverPrune":
+        """Return a dynamically pruned retriever.
+
+        Args:
+            topk (int, optional): Number of documents to return per query. Defaults to 1000.
+            ub_inflation (float, optional): Multiplier applied to pruning upper bounds; 
+                larger values prune less aggressively. Defaults to 1.0.
+
+        See Also:
+            https://arxiv.org/pdf/2505.00560
+        
+        """
         return JPQRetrieverPrune(self.docnos, self.codes, self.dvecs, topk=topk, name="JPQ-Prune", ub_inflation=ub_inflation, opq = self.opq)

--- a/pyterrier_dr/jpq/train.py
+++ b/pyterrier_dr/jpq/train.py
@@ -39,8 +39,42 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-
 class JPQTrainer:
+    """Trainer for Joint Product Quantization.
+
+    JPQTrainer expects an existing :class:`FlexIndex` and a :class:`BiEncoder`.
+    It first learns PQ centroids for document vectors in the provided index,
+    then jointly fine-tunes the learned centroids and the provided query encoder.
+
+    Call :meth:`fit` to train JPQ. Then call :meth:`jpq_index` to save the resulting :class:`JPQIndex`.
+
+    Args:
+        backbone_model (BiEncoder): The query encoder to be trained.
+        index (FlexIndex): The document index for training PQ centroids.
+        device (str): Device. If None, an available device is selected automatically.
+        pq_impl (Literal['faiss','sklearn','faiss2', 'faiss2opq'], optional):
+            PQ implementation. Defaults to 'sklearn'.
+        M (int, optional): Number of splits. 
+            The original embedding dimension must be divisible by this value. Defaults to 8.
+        nbits (int, optional): Number of bits per split.
+            The corresponding number of centroids per split is `2**nbits`.
+            Expect a value between 4 and 16 inclusive. Defaults to 8.
+        train_query_encoder (bool, optional): Whether to fine-tune the query encoder.
+            If False, only the PQ centroids will be fine-tuned. Defaults to True.
+    
+    Attributes:
+        fitted (bool): Whether :meth:`fit` is called.
+        query_encoder (BiEncoder): The query encoder.
+        index (FlexIndex): The document index for training PQ centroids.
+        M (int): Number of splits. 
+        d (int): Original embedding dimension.
+        nbits (int, optional): Number of bits per split.
+        Ks (int): The corresponding number of centroids per split, i.e. `2**nbits`.
+        device (str): Device.
+        train_query_encoder (bool): Whether to fine-tune the query encoder.
+            If False, only the PQ centroids will be fine-tuned.
+            
+    """
 
     def __init__(
         self,
@@ -414,7 +448,7 @@ class JPQTrainer:
 
 
     def fit(self,
-        training_docpairs,
+        training_docpairs: list[dict[str, str]],
         pq_sample_size: int = 10_000, # how many doc vectors to use to train PQ centroids
         docid_subset: list[int] | list[str] | int | None = None, # how many doc vectors to use to train the sub-id embeddings 
         batch_size: int = 32,
@@ -429,7 +463,51 @@ class JPQTrainer:
         lambda_rank : bool = False,
         checkpoint_dir : str|None = None,
         pq_only: bool = False,
-    ):
+    ) -> None:
+        """Train JPQ.
+
+        This first trains PQ centroids over document vectors from :attr:`index`, 
+        then jointly optimizes the learned centroids and the query encoder on the provided training data. 
+        After fitting, call :meth:`jpq_index` to build a searchable :class:`JPQIndex`.
+
+        Args:
+            training_docpairs (list[dict[str, str]]): Training data. Each item
+                must contain ``query`` text, ``doc_id_a`` for the positive
+                document docno, and ``doc_id_b`` for the negative document docno.
+                When ``docid_subset`` is used, pairs whose positive or negative
+                document is outside the subset are filtered out.
+            pq_sample_size (int, optional): Number of document vectors for training
+                PQ centroids. If ``docid_subset`` is also provided, will sample from the subset.
+                Otherwise they are sampled from the full set of document vectors.
+                Defaults to 10,000.
+            docid_subset (list[int] | list[str] | int | None, optional): A sequence of
+                ``docid`` or ``docno`` to be included for training. ``training_docpairs`` 
+                with documents outside this subset will be filtered out. If an integer is provided,
+                a subset of the given size will be randomly sampled.
+                If None, all documents are used.  Defaults to None.
+            batch_size (int, optional): Training batch size. Defaults to 32.
+            total_steps (int, optional): Maximum number of training steps.
+                Defaults to 1,000,000,000.
+            patience (int, optional): Number of validations without improvement
+                before early stopping. Defaults to 5.
+            lr (float, optional): Learning rate. Defaults to 2e-5.
+            eval_queries (pd.DataFrame | None, optional): Validation queries. Must be
+                provided with eval_qrels to run validation. Defaults to None.
+            eval_qrels (pd.DataFrame | None, optional): Validation qrels. Must be
+                provided with eval_queries to run validation. Defaults to None.
+            valid_every (int, optional): Run validation every this many training
+                steps. Defaults to 25.
+            in_batch (bool, optional): Whether to use in-batch negatives during training.
+                Defaults to False.
+            jpq_negs (int, optional): Number of JPQ negatives to sample per query.
+                Defaults to 0.
+            lambda_rank (bool, optional): Whether to use LambdaRank for training loss.
+                Defaults to False.
+            checkpoint_dir (str): Directory for saving checkpoints. Defaults to None.
+            pq_only (bool, optional): Train PQ centroids only. No further joint optimization 
+                of PQ centroids and the query encoder. Defaults to False.
+
+        """
         start_time = time.time()
         selected_docnos, selected_docids, docno2pos, needs_filtered = get_pq_training_dataset(self.index, docid_subset)
         codes, centroids, pq = self._compute_PQ(pq_sample_size, selected_docids, self.index.payload()[1])

--- a/pyterrier_dr/pt_docs/api.rst
+++ b/pyterrier_dr/pt_docs/api.rst
@@ -97,6 +97,15 @@ Diversity
 .. autofunction:: pyterrier_dr.ILS
 .. autofunction:: pyterrier_dr.ils
 
+Joint Product Quantization
+=====================================================
+
+.. autoclass:: pyterrier_dr.jpq.JPQTrainer
+    :members: fit, jpq_index
+
+.. autoclass:: pyterrier_dr.jpq.JPQIndex
+    :members: docnos, codes, dvecs, opq, retriever_pq, retriever_flat, retriever_prune, build_zero_shot_index
+
 Deprecated
 ====================================================
 

--- a/pyterrier_dr/pt_docs/index.rst
+++ b/pyterrier_dr/pt_docs/index.rst
@@ -40,6 +40,7 @@ you will need to install the FAISS package:
     Indexing & Retrieval <indexing-retrieval>
     Pseudo-Relevance Feedback <prf>
     Diversity <diversity>
+    Joint Product Quantization <jpq>
     How-To Guides <how-to>
     API Reference <api>
 

--- a/pyterrier_dr/pt_docs/jpq.rst
+++ b/pyterrier_dr/pt_docs/jpq.rst
@@ -1,0 +1,83 @@
+Joint Product Quantization
+=====================================================
+
+Joint Product Quantization (JPQ) first learns product quantization (PQ) 
+centroids over document embeddings from an existing index, 
+then jointly optimizes these centroids and the query encoder.
+
+Training
+-----------------------------------------------------
+
+JPQ training requires:
+
+- A :class:`~pyterrier_dr.BiEncoder`
+- A :class:`~pyterrier_dr.FlexIndex` containing document embeddings produced by the :class:`~pyterrier_dr.BiEncoder`
+- A list of training examples, where each item is a ``dict`` containing
+    - ``query`` (str): the input query text
+    - ``doc_id_a`` (str): document identifier for a relevant (positive) document
+    - ``doc_id_b`` (str): document identifier for a non-relevant (negative) document
+
+
+:class:`pyterrier_dr.JPQTrainer` implements the training code.
+Call :meth:`~pyterrier_dr.JPQTrainer.fit` to train JPQ. After training, call :meth:`~pyterrier_dr.JPQTrainer.jpq_index` 
+to save the :class:`~pyterrier_dr.JPQIndex`. See example below:
+
+.. code-block:: python
+    :caption: Example for training JPQ with E5
+
+    from pyterrier_dr import FlexIndex, JPQTrainer, E5
+
+    index = FlexIndex("path/to/e5_index")
+    model = E5()
+    trainer = JPQTrainer(model, index, M=96, nbits=8, pq_impl="faiss2opq")
+
+    training_docpairs = [
+        {
+            "query": "chemical reactions in water",
+            "doc_id_a": "doc_1",
+            "doc_id_b": "doc_2",
+        },
+        # ...
+    ]
+    save_path = "e5_jpq"
+    trainer.fit(training_docpairs=training_docpairs)
+    jpq_index = trainer.jpq_index(save_path)
+    trainer.query_encoder.model.save_pretrained(save_path)
+
+
+
+Retrieval
+-----------------------------------------------------
+
+JPQ retrieval requires:
+
+- The fine-tuned query encoder
+- The corresponding :class:`~pyterrier_dr.JPQIndex`
+
+With a :class:`~pyterrier_dr.JPQIndex`, you can create a PQ retriever by calling
+:meth:`~pyterrier_dr.JPQIndex.retriever_pq`. An example is provided below:
+
+.. code-block:: python
+    :caption: Example for retrieval using JPQ (E5)
+
+    from pyterrier_dr import JPQIndex, E5
+    from sentence_transformers import SentenceTransformer
+
+    path = "e5_jpq"
+
+    model = E5()
+    model.model = SentenceTransformer(path, device="cuda")
+    jpq_index = JPQIndex(path)
+
+    pipeline = model.query_encoder() >> jpq_index.retriever_pq()
+    results = pipeline.search("chemical reactions in water")
+
+
+API Reference
+-----------------------------------------------------
+
+.. autoclass:: pyterrier_dr.JPQTrainer
+    :members: fit, jpq_index
+
+.. autoclass:: pyterrier_dr.JPQIndex
+    :members: docnos, codes, dvecs, opq, retriever_pq, retriever_flat, retriever_prune, build_zero_shot_index


### PR DESCRIPTION
This PR adds documentation for JPQ. Changes include:
- added`JPQTrainer` and `JPQIndex` to `pyterrier_dr/__init__.py`
- added docstrings for `pyterrier_dr.jpq.train.JPQTrainer` and `pyterrier_dr.jpq.index.JPQIndex`
- created `pt_docs/jpq.rst`; added to `pt_docs/index.rst`
- added related API references to `pt_docs/api.rst`
