### PR TITLE
JPQ notebook NQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ retr_pipeline = model >> index.faiss_hnsw_retriever()
 
 PyTerrier_DR provides training and retrieval code for Joint Product Quantisation. We published a reproducibility paper - see https://dl.acm.org/doi/10.1145/3805712.3808565.
 
-Want to try it out? See our notebook for MSMARCO: [jpq-tct-replication.ipynb](examples/jpq-tct-replication.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/terrier-org/pyterrier/blob/master/examples/notebooks/indexing.ipynb)
+Want to try it out? See our notebooks below. 
+- MSMARCO: [jpq-tct-replication.ipynb](examples/jpq-tct-replication.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/terrierteam/pyterrier_dr/blob/main/examples/jpq-tct-replication.ipynb)
+- NQ: [jpq-tct-nq.ipynb](examples/jpq-tct-nq.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/terrierteam/pyterrier_dr/blob/main/examples/jpq-tct-nq.ipynb)
+
 
 ### Training
 

--- a/examples/jpq-tct-nq.ipynb
+++ b/examples/jpq-tct-nq.ipynb
@@ -1,0 +1,3059 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "78480647-44e5-439a-b80d-d50a6895f70b",
+   "metadata": {},
+   "source": [
+    "### Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0de69366-7d1f-49b4-ab7c-7d0af442d562",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: The directory '/mnt/primary/launcher-cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.\u001b[0m\u001b[33m\n",
+      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "pip install -q transformers==4.57.1 vllm==0.8.* faiss-cpu datasets pyterrier_dr[jpq] pyterrier_rag "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ab178c3-e71e-4d47-bc04-c2a438460512",
+   "metadata": {},
+   "source": [
+    "### Loading a JPQ Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f3102ff3-4b11-426b-a605-9c8c13cb693f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n",
+      "2026-07-17 13:41:08 INFO     Using default tokenizer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from functools import cache\n",
+    "\n",
+    "import pyterrier_dr as ptd\n",
+    "import pyterrier_dr.jpq\n",
+    "import pyterrier as pt\n",
+    "import pyterrier_rag as ptr\n",
+    "import pandas as pd\n",
+    "import datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dca7bbc9-f2d0-43ce-ba0e-3e75c14e6742",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1549855e77a9472dab14af9dec1f6427",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "https://huggingface.co/datasets/jpq-repro/nq-train__tct_colbert__faiss2opq__M96_nbits8__ps159744__neg200__ibn_…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "extracting codes.f4 [1.9 GB]\n",
+      "extracting config.json [618 B]\n",
+      "extracting docnos.npids [207 B]\n",
+      "extracting model.safetensors [417.7 MB]\n",
+      "extracting opq.f4 [2.2 MB]\n",
+      "extracting pt_meta.json [107 B]\n",
+      "extracting subvecs.f4 [768.0 KB]\n"
+     ]
+    }
+   ],
+   "source": [
+    "index = pyterrier_dr.jpq.JPQIndex.from_hf(\"jpq-repro/nq-train__tct_colbert__faiss2opq__M96_nbits8__ps159744__neg200__ibn__lr__\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "98732db4-86cc-4058-abf6-541c4e493f24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/root/.pyterrier/artifacts/fd1ff7f570938e907814aed4afac73dc9a59850e64f0a9b13686794b93d16588\n",
+      "total 2.3G\n",
+      "-rw-r--r--. 1 root root 1.9G Jul 17 13:43 codes.f4\n",
+      "-rw-r--r--. 1 root root  618 Jul 17 13:43 config.json\n",
+      "-rw-r--r--. 1 root root  207 Jul 17 13:43 docnos.npids\n",
+      "-rw-r--r--. 1 root root 418M Jul 17 13:44 model.safetensors\n",
+      "-rw-r--r--. 1 root root 2.3M Jul 17 13:44 opq.f4\n",
+      "-rw-r--r--. 1 root root  107 Jul 17 13:44 pt_meta.json\n",
+      "-rw-r--r--. 1 root root 768K Jul 17 13:44 subvecs.f4\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -d {index.path}\n",
+    "!ls -lh {index.path}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d383fa3-b175-41c1-984b-d2d381b7e7ed",
+   "metadata": {},
+   "source": [
+    "\n",
+    "You should see the following files:\n",
+    "- `subvecs.f4`: the centroid embeddings (768KB)\n",
+    "- `opq.f4`: the OPQ rotation matrix (2.3MB)\n",
+    "- `codes.f4`: the codebook assigning documents to centroids (1.9GB)\n",
+    "\n",
+    "**Note**: The jointly trained query encoder is saved under the same directory; we will load this checkpoint later for retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a46b843f-7465-456a-85a5-6f0ac932343b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "21015324"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d2fcf18-7179-4915-9c9e-2730374970ff",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "### NQ Dataset\n",
+    "\n",
+    "Since NQ test split is not available through [ir_datasets](https://ir-datasets.com/natural-questions.html), here we implement an adapter to load it from [FlashRAG](https://huggingface.co/datasets/RUC-NLPIR/FlashRAG_datasets)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "461f2472-db70-4ebf-9e74-2e8b43a35675",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@cache\n",
+    "def _load(split: str) -> datasets.Dataset:\n",
+    "    return datasets.load_dataset(\"RUC-NLPIR/FlashRAG_datasets\", \"nq\", split=split)\n",
+    "\n",
+    "def get_topics(split: str) -> pd.DataFrame:\n",
+    "    dataset = _load(split)\n",
+    "    df = dataset.to_pandas().drop(\"golden_answers\", axis=1)\n",
+    "    return df.rename({\"id\": \"qid\", \"question\": \"query\"}, axis=1)\n",
+    "\n",
+    "def get_answers(split: str) -> pd.DataFrame:\n",
+    "    dataset = _load(split)\n",
+    "    data = []\n",
+    "    index = []\n",
+    "    for idx, item in enumerate(dataset):\n",
+    "        qid = item[\"id\"]\n",
+    "        gold_answers = item[\"golden_answers\"]\n",
+    "        for gold_answer in gold_answers:\n",
+    "            data.append([qid, gold_answer])\n",
+    "            index.append(idx)\n",
+    "    \n",
+    "    return pd.DataFrame(data, index=index, columns=[\"qid\", \"gold_answer\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "946d9b01-1410-4101-a8ce-596f5b6621fb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bb57de3-8fac-482d-a4b4-9a11662aeabe",
+   "metadata": {},
+   "source": [
+    "### Prompt & LLM Reader\n",
+    "\n",
+    "Here we define a simple prompt and instantiate an LLM reader using [pyterrier_rag](https://github.com/terrierteam/pyterrier_rag/tree/main)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c9b5b6e1-b5cd-4711-a704-642bc3cbcae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import PreTrainedTokenizerBase\n",
+    "from pyterrier_rag.readers import Reader\n",
+    "from pyterrier_rag.prompt import Concatenator, PromptTransformer\n",
+    "from pyterrier_rag.backend import TextGenerator, VLLMBackend, HuggingFaceBackend\n",
+    "\n",
+    "# See Also: https://github.com/yuwvandy/KG-LLM-MDQA/blob/main/Pipeline/prompt.py\n",
+    "_PROMPT = \"\"\"Given the following documents:\n",
+    "{qcontext}\n",
+    "\n",
+    "Answer the following question: {query}\n",
+    "\n",
+    "Your answer should be concise (no more than 6 words) and no explanation is needed.\n",
+    "Answer:\"\"\"\n",
+    "\n",
+    "\n",
+    "class PromptTransformerV2(PromptTransformer):\n",
+    "    def __init__(self, tokenizer: PreTrainedTokenizerBase, raw_prompt: str, *args, **kwargs) -> None:\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "        self.raw_prompt = raw_prompt\n",
+    "        self.tokenizer = tokenizer\n",
+    "\n",
+    "    def create_prompt(self, fields: dict) -> str:\n",
+    "        prompt = self.raw_prompt.format(**{k: fields[k] for k in self.input_fields})\n",
+    "        if self.tokenizer.chat_template:\n",
+    "            prompt = self.tokenizer.apply_chat_template(\n",
+    "                [\n",
+    "                    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+    "                    {\"role\": \"user\", \"content\": prompt},\n",
+    "                ],\n",
+    "                add_generation_prompt=True,\n",
+    "                tokenize=False,\n",
+    "            )\n",
+    "\n",
+    "        return prompt\n",
+    "\n",
+    "\n",
+    "def format_doc(title: str, text: str) -> str:\n",
+    "    title = title.strip('\"')\n",
+    "    text = text.removeprefix(title).lstrip()\n",
+    "    return f\"Title: {title}\\nText: {text}\\n\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "49d96adb-ee95-45c5-82ff-b2caedf59364",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 07-17 13:44:13 [importing.py:53] Triton module has been replaced with a placeholder.\n",
+      "INFO 07-17 13:44:13 [__init__.py:239] Automatically detected platform cuda.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "`torch_dtype` is deprecated! Use `dtype` instead!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 07-17 13:44:30 [config.py:717] This model supports multiple tasks: {'reward', 'generate', 'classify', 'score', 'embed'}. Defaulting to 'generate'.\n",
+      "INFO 07-17 13:44:30 [config.py:2003] Chunked prefill is enabled with max_num_batched_tokens=65536.\n",
+      "INFO 07-17 13:44:40 [__init__.py:239] Automatically detected platform cuda.\n",
+      "INFO 07-17 13:44:44 [core.py:58] Initializing a V1 LLM engine (v0.8.5.post1) with config: model='Qwen/Qwen2.5-3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen2.5-3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='auto', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=Qwen/Qwen2.5-3B-Instruct, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={\"level\":3,\"custom_ops\":[\"none\"],\"splitting_ops\":[\"vllm.unified_attention\",\"vllm.unified_attention_with_output\"],\"use_inductor\":true,\"compile_sizes\":[],\"use_cudagraph\":true,\"cudagraph_num_of_warmups\":1,\"cudagraph_capture_sizes\":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],\"max_capture_size\":512}\n",
+      "WARNING 07-17 13:44:44 [utils.py:2522] Methods determine_num_available_blocks,device_config,get_cache_block_size_bytes,initialize_cache not implemented in <vllm.v1.worker.gpu_worker.Worker object at 0x7ff6877c4460>\n",
+      "INFO 07-17 13:44:45 [parallel_state.py:1004] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0\n",
+      "INFO 07-17 13:44:45 [cuda.py:221] Using Flash Attention backend on V1 engine.\n",
+      "WARNING 07-17 13:44:45 [topk_topp_sampler.py:69] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.\n",
+      "INFO 07-17 13:44:45 [gpu_model_runner.py:1329] Starting to load model Qwen/Qwen2.5-3B-Instruct...\n",
+      "INFO 07-17 13:44:45 [weight_utils.py:265] Using model weights format ['*.safetensors']\n",
+      "INFO 07-17 13:44:50 [weight_utils.py:281] Time spent downloading weights for Qwen/Qwen2.5-3B-Instruct: 5.398609 seconds\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]\n",
+      "Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  4.09it/s]\n",
+      "Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  2.64it/s]\n",
+      "Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  2.79it/s]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 07-17 13:44:51 [loader.py:458] Loading weights took 0.82 seconds\n",
+      "INFO 07-17 13:44:52 [gpu_model_runner.py:1347] Model loading took 5.7916 GiB and 6.892856 seconds\n",
+      "INFO 07-17 13:45:00 [backends.py:420] Using cache directory: /root/.cache/vllm/torch_compile_cache/cc9fb514dc/rank_0_0 for vLLM's torch.compile\n",
+      "INFO 07-17 13:45:00 [backends.py:430] Dynamo bytecode transform time: 8.38 s\n",
+      "INFO 07-17 13:45:07 [backends.py:118] Directly load the compiled graph(s) for shape None from the cache, took 6.319 s\n",
+      "INFO 07-17 13:45:08 [monitor.py:33] torch.compile takes 8.38 s in total\n",
+      "INFO 07-17 13:45:14 [kv_cache_utils.py:634] GPU KV cache size: 218,160 tokens\n",
+      "INFO 07-17 13:45:14 [kv_cache_utils.py:637] Maximum concurrency for 32,768 tokens per request: 6.66x\n",
+      "INFO 07-17 13:45:36 [gpu_model_runner.py:1686] Graph capturing finished in 22 secs, took 1.80 GiB\n",
+      "INFO 07-17 13:45:36 [core.py:159] init engine (profile, create kv cache, warmup model) took 44.01 seconds\n",
+      "INFO 07-17 13:45:36 [core_client.py:439] Core engine process 0 ready.\n"
+     ]
+    }
+   ],
+   "source": [
+    "backend = ptr.VLLMBackend(\n",
+    "    \"Qwen/Qwen2.5-3B-Instruct\",\n",
+    "    model_args={\n",
+    "        \"gpu_memory_utilization\": 0.8,\n",
+    "        \"max_num_seqs\": 256,\n",
+    "        \"max_num_batched_tokens\": 2**16,\n",
+    "    },\n",
+    "    generation_args={\n",
+    "        \"max_tokens\": 32,\n",
+    "        \"temperature\": 0,\n",
+    "    },\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "eb6267f3-7e59-4cfc-87ce-b0f568afe298",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reader = Reader(\n",
+    "    backend=backend, \n",
+    "    prompt=PromptTransformerV2(backend.model.get_tokenizer(), raw_prompt=_PROMPT, model_name_or_path=backend.model_id)\n",
+    ")\n",
+    "reader.backend.batch_size = 32\n",
+    "reader = Concatenator(in_fields=[\"title\", \"text\"], intermediate_format=format_doc) >> reader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60eb6172-b458-4536-8c67-f163fcc45d44",
+   "metadata": {},
+   "source": [
+    "### RAG pipeline\n",
+    "\n",
+    "We can then construct a RAG pipeline and evaluate it on the NQ test split."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6129a227-c577-4024-975a-5e706598286c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "encoder = pyterrier_dr.TctColBert.hnp()\n",
+    "encoder.model = encoder.model.from_pretrained(index.path).eval().to(\"cuda\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c25f385b-52a4-4577-a3c0-c9d2879da02f",
+   "metadata": {},
+   "source": [
+    "The `text_loader` below fetches document content (`title` and `text`) given retrieved document IDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "824df426-4dc5-42f0-bf0f-3546973e1cd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Java started (triggered by TerrierIndex.index_ref) and loaded: pyterrier.java.colab, pyterrier.java, pyterrier.java.24, pyterrier.terrier.java [version=5.11 (build: craig.macdonald 2025-01-13 21:29), helper_version=0.0.8]\n"
+     ]
+    }
+   ],
+   "source": [
+    "text_loader = pt.Artifact.from_hf(\"pyterrier/ragwiki-terrier\").text_loader([\"docno\", \"title\", \"text\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "bc882c63-f8dc-431c-aaad-b64586a90cc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jpq_rag = encoder.query_encoder(batch_size=256) >> index.retriever_pq(topk=5) >> text_loader >> reader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "48486977-0f34-49a5-9e7d-ccee4e2952f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div id=\"id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f\" class=\"repr_html\" style=\"display: none;\">\n",
+       "        <style>#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f {\n",
+       "  color-scheme: light dark;\n",
+       "  --pts-fg: #000000;\n",
+       "  --pts-bg: #FFFFFF;\n",
+       "  --pts-bg-hov: #DDDDDD;\n",
+       "  --pts-alert: #a35;\n",
+       "  --pts-bg-hl: #cbdff4;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f-pts-rendering-issue {\n",
+       "  display: none;\n",
+       "}\n",
+       "@media (prefers-color-scheme: dark) {\n",
+       "  #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f {\n",
+       "    --pts-fg: #FFFFFF;\n",
+       "    --pts-bg: #000000;\n",
+       "    --pts-bg-hov: #444444;\n",
+       "    --pts-bg-hl: #22476e;\n",
+       "  }\n",
+       "}\n",
+       "[data-theme=\"dark\"] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f, [theme=\"dark\"] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f, [data-jp-theme-dark=\"true\"] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f {\n",
+       "  --pts-fg: #FFFFFF;\n",
+       "  --pts-bg: #000000;\n",
+       "  --pts-bg-hov: #444444;\n",
+       "  --pts-bg-hl: #22476e;\n",
+       "}\n",
+       "[data-theme=\"light\"] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f, [theme=\"light\"] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f, [data-jp-theme-light=\"true\"] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f {\n",
+       "  --pts-fg: #000000;\n",
+       "  --pts-bg: #FFFFFF;\n",
+       "  --pts-bg-hov: #DDDDDD;\n",
+       "  --pts-bg-hl: #cbdff4;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f {\n",
+       "    position: relative;\n",
+       "    min-height: 32px;\n",
+       "    padding: 16px;\n",
+       "    --jp-ui-font-size1: 12px;\n",
+       "    display: flex !important; /* Some notebooks don't render CSS from other sources, so we set an inline display: none; which this reverts */\n",
+       "    justify-content: center;\n",
+       "    font-size: 12px;\n",
+       "    font-family: Arial, sans-serif;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f.repr_html {\n",
+       "    /* when the shown in a notebook, make sure we have sufficient height to show infoboxes */\n",
+       "    min-height: 96px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-hint {\n",
+       "    display: none;\n",
+       "    position: absolute;\n",
+       "    top: 1px;\n",
+       "    right: 2px;  \n",
+       "    background: #f59f00;\n",
+       "    color: #fff;\n",
+       "    padding: 0 2px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox {\n",
+       "    position: absolute;\n",
+       "    max-height: calc(100% - 8px);\n",
+       "    top: 0;\n",
+       "    left: 0;\n",
+       "    border: 1px solid rgb(66, 153, 225);\n",
+       "    overflow-y: auto;\n",
+       "    display: none;\n",
+       "    background: var(--pts-bg);\n",
+       "    box-shadow: 0 0 4px var(--pts-fg);\n",
+       "    opacity: 1;\n",
+       "    margin: 4px;\n",
+       "    font-size: 0.8em;\n",
+       "    max-width: 360px;\n",
+       "    min-width: 128px;\n",
+       "    z-index: 9999;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f.repr_html .pts-infobox {\n",
+       "    max-height: calc(100% - 8px);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-item {\n",
+       "    display: none;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-title {\n",
+       "    background: rgb(66, 153, 225);\n",
+       "    color: white;\n",
+       "    padding: 2px 6px;\n",
+       "    position: sticky;\n",
+       "    top: 0;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-body {\n",
+       "    overflow-x: auto;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f [data-pts-infobox] {\n",
+       "    cursor: pointer;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-source.pts-transformer {\n",
+       "    background: rgba(66, 153, 225, 0.4);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-source.pts-df {\n",
+       "    background-color: var(--pts-bg-hov);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-outer-error {\n",
+       "    border: 1px solid var(--pts-alert);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-outer-error > .pts-infobox-title {\n",
+       "    background: var(--pts-alert);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-error {\n",
+       "    margin: 4px;\n",
+       "    color: var(--pts-alert);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-error ul {\n",
+       "    margin: 0;\n",
+       "    padding-left: 12px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-hline {\n",
+       "    width: 56px;\n",
+       "    border-bottom: 2px solid var(--pts-fg);\n",
+       "    align-self: center;\n",
+       "    position: relative;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-arr-inner {\n",
+       "    margin-right: -6px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-arr-input {\n",
+       "    margin-right: -6px;\n",
+       "    width: 16px;\n",
+       "    margin-left: 28px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-arr-output {\n",
+       "    width: 16px;\n",
+       "    margin-right: 32px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-arr::after {\n",
+       "    content: \"\";\n",
+       "    position: absolute;\n",
+       "    right: -4px;\n",
+       "    top: 1px;\n",
+       "    transform: translateY(-50%);\n",
+       "    width: 0;\n",
+       "    height: 0;\n",
+       "    border-left: 6px solid var(--pts-fg);\n",
+       "    border-top: 4px solid transparent;\n",
+       "    border-bottom: 4px solid transparent;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-io-label {\n",
+       "    margin: 0 5px 4px 5px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-vline {\n",
+       "    border-right: 2px solid var(--pts-fg);\n",
+       "    position: relative;\n",
+       "    margin-right: -2px;\n",
+       "    margin-left: -2px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df {\n",
+       "    display: inline-block;\n",
+       "    width: 27px;\n",
+       "    height: 27px;\n",
+       "    font-size: 14px;\n",
+       "    color: var(--pts-fg);\n",
+       "    border: 3px double var(--pts-fg);\n",
+       "    background-color: var(--pts-bg);\n",
+       "    box-sizing: border-box;\n",
+       "    border-radius: 3px;\n",
+       "    text-align: center;\n",
+       "    line-height: 1;\n",
+       "    padding-top: 3px;\n",
+       "    margin: 1px;\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df.pts-df-alert {\n",
+       "    border-color: var(--pts-alert);\n",
+       "    color: var(--pts-alert);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-hline > .pts-df {\n",
+       "    position: absolute;\n",
+       "    top: -14px;\n",
+       "    left: 12px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-arr-input > .pts-df {\n",
+       "    left: -28px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-arr-output > .pts-df {\n",
+       "    left: 22px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df-columns {\n",
+       "    margin-bottom: 0;\n",
+       "    min-width: 100%;\n",
+       "    border-collapse: collapse;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df-columns td, #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df-columns th {\n",
+       "    border-top: 1px solid #bbb;\n",
+       "    background: var(--pts-bg);\n",
+       "    color: var(--pts-fg);\n",
+       "    text-align: left;\n",
+       "    padding: 2px 2px 2px 4px;\n",
+       "    white-space: nowrap;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df-columns .pts-add th, #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df-columns .pts-add td {\n",
+       "    background-color: var(--pts-bg-hl);\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-df-columns td {\n",
+       "    width: 100%;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-pipeline {\n",
+       "    display: flex;\n",
+       "    align-items: center;\n",
+       "    align-content: stretch;\n",
+       "    min-height: 50px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-tree-scroll {\n",
+       "    width: 100%;\n",
+       "    overflow-x: auto;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-tree-scroll > .pts-pipeline {\n",
+       "    width: max-content;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-pipeline > * {\n",
+       "    flex-shrink: 0;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-transformer {\n",
+       "    font-size: 13px;\n",
+       "    display: inline-block;\n",
+       "    position: relative;\n",
+       "    color: var(--pts-fg);\n",
+       "    /* background can be overridden by pts-node-bg, e.g. pt.Experiment progress */\n",
+       "    background: var(--pts-node-bg, rgba(66, 153, 225, 0.3));\n",
+       "    box-sizing: border-box;\n",
+       "    padding: 4px 18px;\n",
+       "    clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%, 16px 50%);\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-transformer-title {\n",
+       "    text-align: center;\n",
+       "    font-weight: bold;\n",
+       "}\n",
+       "\n",
+       "/* re-size things within an inner block */\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-df {\n",
+       "    width: 21px;\n",
+       "    height: 21px;\n",
+       "    font-size: 11px;\n",
+       "    padding-top: 2px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-hline {\n",
+       "    width: 34px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-transformer {\n",
+       "    font-size: 12px;\n",
+       "    padding: 3px 18px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-hline > .pts-df {\n",
+       "    position: absolute;\n",
+       "    top: -10px;\n",
+       "    left: 5px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-arr-input {\n",
+       "    margin-left: 8px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-arr-output {\n",
+       "    margin-right: 4px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner-schematic {\n",
+       "    display: flex;\n",
+       "    flex-direction: column;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-scaffold {\n",
+       "    display: grid;\n",
+       "    grid-template-areas:\n",
+       "      \"larr title rarr\"\n",
+       "      \"larr body  rarr\";\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-scaffold > .pts-hline {\n",
+       "    grid-area: larr;\n",
+       "    width: 16px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-scaffold > .pts-hline.pts-arr {\n",
+       "    grid-area: rarr;\n",
+       "    margin-right: -8px;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-scaffold > .pts-transformer-title {\n",
+       "    grid-area: title;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-scaffold > .pts-inner-schematic {\n",
+       "    grid-area: body;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-item {\n",
+       "    display: flex;\n",
+       "    align-content: stretch;\n",
+       "    justify-content: stretch;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-item:first-child > .pts-vline {\n",
+       "    height: 50%;\n",
+       "    align-self: end;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-item:last-child > .pts-vline {\n",
+       "    height: 50%;\n",
+       "    align-self: start;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-parallel-item > .pts-pipeline {\n",
+       "    flex-grow: 1;\n",
+       "    margin: 4px 0;\n",
+       "}\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner .pts-pipeline {\n",
+       "    overflow-x: visible;\n",
+       "    min-height: 25px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-combine-box {\n",
+       "    border: 1px dashed #999;\n",
+       "    display: flex;\n",
+       "    align-items: center;\n",
+       "    margin-right: -8px;\n",
+       "    padding-right: 8px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-inner-labeled > .pts-transformer-title {\n",
+       "    font-weight: normal;\n",
+       "    margin-top: 2px;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-transformer.pts-input-validation-error {\n",
+       "    background: rgba(255, 101, 101, 0.3);\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-artifact-icon {\n",
+       "  position: absolute;\n",
+       "  left: 22px;\n",
+       "  width: 24px;\n",
+       "  height: 24px;\n",
+       "  max-width: 24px;\n",
+       "  top: -12px;\n",
+       "}\n",
+       "\n",
+       "[data-vscode] #id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f a {\n",
+       "    /* links don't work in vscode, so pretend they don't exist */\n",
+       "    color: inherit;\n",
+       "    text-decoration: none;\n",
+       "}\n",
+       "\n",
+       "\n",
+       "/* change colors acc to status */\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-transformer.pts-pending {\n",
+       "    --pts-node-bg: rgba(220, 38, 38, 0.6); /* red */\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-transformer.pts-running {\n",
+       "    --pts-node-bg: rgba(250, 204, 21, 0.7); /* yellow */\n",
+       "    color: #000;\n",
+       "}\n",
+       "\n",
+       "#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-transformer.pts-done {\n",
+       "    --pts-node-bg: rgba(22, 163, 74, 0.6); /* green */\n",
+       "}</style>\n",
+       "        <div class=\"pts-infobox\">\n",
+       "            <div class=\"pts-infobox-title\"></div>\n",
+       "            <div class=\"pts-infobox-body\"></div>\n",
+       "            <div class=\"pts-infobox-hint\"><svg  xmlns=\"http://www.w3.org/2000/svg\"  width=\"24\"  height=\"24\"  viewBox=\"0 0 24 24\"  fill=\"currentColor\"  style=\"width: 12px; height: 12px; vertical-align: -2px;\"><path stroke=\"none\" d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M4 11a1 1 0 0 1 .117 1.993l-.117 .007h-1a1 1 0 0 1 -.117 -1.993l.117 -.007h1z\" /><path d=\"M12 2a1 1 0 0 1 .993 .883l.007 .117v1a1 1 0 0 1 -1.993 .117l-.007 -.117v-1a1 1 0 0 1 1 -1z\" /><path d=\"M21 11a1 1 0 0 1 .117 1.993l-.117 .007h-1a1 1 0 0 1 -.117 -1.993l.117 -.007h1z\" /><path d=\"M4.893 4.893a1 1 0 0 1 1.32 -.083l.094 .083l.7 .7a1 1 0 0 1 -1.32 1.497l-.094 -.083l-.7 -.7a1 1 0 0 1 0 -1.414z\" /><path d=\"M17.693 4.893a1 1 0 0 1 1.497 1.32l-.083 .094l-.7 .7a1 1 0 0 1 -1.497 -1.32l.083 -.094l.7 -.7z\" /><path d=\"M14 18a1 1 0 0 1 1 1a3 3 0 0 1 -6 0a1 1 0 0 1 .883 -.993l.117 -.007h4z\" /><path d=\"M12 6a6 6 0 0 1 3.6 10.8a1 1 0 0 1 -.471 .192l-.129 .008h-6a1 1 0 0 1 -.6 -.2a6 6 0 0 1 3.6 -10.8z\" /></svg> Click to explore!</div>\n",
+       "        </div>\n",
+       "        <div class=\"pts-pipeline\"><div class=\"pts-io-label\">Input</div><div class=\"pts-hline pts-arr pts-arr-input\"><div class=\"pts-df \" data-pts-infobox=\"id-fee097b2-69ef-41f5-a1a5-5e655206c933\">Q\n",
+       "        <div id=\"id-fee097b2-69ef-41f5-a1a5-5e655206c933\" class=\"pts-infobox-item\" data-title=\"Query Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qid</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td><i>(Query ID)</i> ID of query in frame </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>query</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Query text </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div>\n",
+       "                <div class=\"pts-transformer \" data-pts-infobox=\"id-ac5af2f9-8389-40d0-a48e-fda652b4a8bf\">\n",
+       "                    \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-ac5af2f9-8389-40d0-a48e-fda652b4a8bf\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                \n",
+       "                    pyterrier_dr.biencoder.BiQueryEncoder\n",
+       "                \n",
+       "            </div>\n",
+       "            \n",
+       "            <table class=\"pts-df-columns\"><tr><th>bi_encoder_model</th><td>TctColBert(&#x27;castorini/tct_colbert-v2-hnp-msmarco&#x27;)</td></tr><tr><th>verbose</th><td>False</td></tr><tr><th>batch_size</th><td>256</td></tr></table>\n",
+       "        </div>\n",
+       "        \n",
+       "                    <div class=\"pts-transformer-title\">BiQueryEncoder</div>\n",
+       "                </div>\n",
+       "                <div class=\"pts-hline pts-arr pts-arr-inner\"><div class=\"pts-df \" data-pts-infobox=\"id-ba5c3f38-66b3-474d-985b-a58e91a452c7\">Q\n",
+       "        <div id=\"id-ba5c3f38-66b3-474d-985b-a58e91a452c7\" class=\"pts-infobox-item\" data-title=\"Query Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qid</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td><i>(Query ID)</i> ID of query in frame </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>query</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Query text </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"pts-add\">\n",
+       "                    <th>query_vec</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">np.array</span></td>\n",
+       "                    <td>Dense query vector </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div>\n",
+       "                <div class=\"pts-transformer \" data-pts-infobox=\"id-70a08877-9f13-48dc-a343-a9bbc78a2e7f\">\n",
+       "                    \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-70a08877-9f13-48dc-a343-a9bbc78a2e7f\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                \n",
+       "                    pyterrier_dr.jpq.retriever.JPQRetrieverPQ\n",
+       "                \n",
+       "            </div>\n",
+       "            \n",
+       "            \n",
+       "        </div>\n",
+       "        \n",
+       "                    <div class=\"pts-transformer-title\">JPQRetrieverPQ</div>\n",
+       "                </div>\n",
+       "                <div class=\"pts-hline pts-arr pts-arr-inner\"><div class=\"pts-df  pts-df-alert\" data-pts-infobox=\"id-13f8f053-ca48-465f-a782-afdf8cfe1736\">?\n",
+       "        <div id=\"id-13f8f053-ca48-465f-a782-afdf8cfe1736\" class=\"pts-infobox-item\" data-title=\"Unknown Frame\">\n",
+       "            <div class=\"pts-infobox-error\">Unknown/incompatible columns</div>\n",
+       "        </div></div></div>\n",
+       "                <div class=\"pts-transformer \" data-pts-infobox=\"id-790810c8-77aa-488d-bdff-ff0d6a24941f\">\n",
+       "                    \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-790810c8-77aa-488d-bdff-ff0d6a24941f\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                \n",
+       "                    pt.terrier._text_loader.TerrierTextLoader\n",
+       "                \n",
+       "            </div>\n",
+       "            \n",
+       "            <table class=\"pts-df-columns\"><tr><th>index</th><td>TerrierIndex(&#x27;/root/.pyterrier/artifacts/ebfd80cc597a31719f11ab5cd11ad8f441bc460f760c82ff66413ba9fb06943f&#x27;)</td></tr><tr><th>fields</th><td>[&#x27;docno&#x27;, &#x27;title&#x27;, &#x27;text&#x27;]</td></tr><tr><th>verbose</th><td>False</td></tr></table>\n",
+       "        </div>\n",
+       "        \n",
+       "                    <div class=\"pts-transformer-title\">TextLoader</div>\n",
+       "                </div>\n",
+       "                <div class=\"pts-hline pts-arr pts-arr-inner\"><div class=\"pts-df  pts-df-alert\" data-pts-infobox=\"id-27c2763f-eb4a-4e5e-9370-1efd8a1124bb\">?\n",
+       "        <div id=\"id-27c2763f-eb4a-4e5e-9370-1efd8a1124bb\" class=\"pts-infobox-item\" data-title=\"Unknown Frame\">\n",
+       "            <div class=\"pts-infobox-error\">Unknown/incompatible columns</div>\n",
+       "        </div></div></div>\n",
+       "                <div class=\"pts-transformer \" data-pts-infobox=\"id-b989a59b-5565-4417-b292-ed98d1012679\">\n",
+       "                    \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-b989a59b-5565-4417-b292-ed98d1012679\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                \n",
+       "                    pyterrier_rag.prompt._context_aggregation.Concatenator\n",
+       "                \n",
+       "            </div>\n",
+       "            \n",
+       "            <table class=\"pts-df-columns\"><tr><th>in_fields</th><td>[&#x27;title&#x27;, &#x27;text&#x27;]</td></tr><tr><th>out_field</th><td>qcontext</td></tr><tr><th>text_loader</th><td>None</td></tr><tr><th>intermediate_format</th><td>&lt;function format_doc at 0x7f873b1e5510&gt;</td></tr><tr><th>tokenizer</th><td>None</td></tr><tr><th>max_length</th><td>-1</td></tr><tr><th>max_elements</th><td>-1</td></tr><tr><th>max_per_context</th><td>-1</td></tr><tr><th>truncation_rate</th><td>50</td></tr><tr><th>aggregate_func</th><td>None</td></tr><tr><th>ordering_func</th><td>&lt;function score_sort at 0x7f85c5640820&gt;</td></tr></table>\n",
+       "        </div>\n",
+       "        \n",
+       "                    <div class=\"pts-transformer-title\">Concatenator</div>\n",
+       "                </div>\n",
+       "                <div class=\"pts-hline pts-arr pts-arr-inner\"><div class=\"pts-df  pts-df-alert\" data-pts-infobox=\"id-29889a86-b032-4798-9831-2fffbaf63a00\">?\n",
+       "        <div id=\"id-29889a86-b032-4798-9831-2fffbaf63a00\" class=\"pts-infobox-item\" data-title=\"Unknown Frame\">\n",
+       "            <div class=\"pts-infobox-error\">Unknown/incompatible columns</div>\n",
+       "        </div></div></div>\n",
+       "                    <div class=\"pts-transformer pts-inner \" data-pts-infobox=\"id-b28b51f1-d24e-4107-b576-d1f89874a82e\">\n",
+       "                        \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-b28b51f1-d24e-4107-b576-d1f89874a82e\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                \n",
+       "                    pyterrier_rag.readers._base.Reader\n",
+       "                \n",
+       "            </div>\n",
+       "            \n",
+       "            <table class=\"pts-df-columns\"><tr><th>output_field</th><td>qanswer</td></tr></table>\n",
+       "        </div>\n",
+       "        \n",
+       "                        <div class=\"pts-transformer-title\">Reader</div>\n",
+       "                        <div class=\"pts-inner-schematic pts-inner-labeled\">\n",
+       "                            <div class=\"pts-transformer-title\">backend</div>\n",
+       "                            <div class=\"pts-inner-schematic pts-inner-labeled\"><div class=\"pts-pipeline\"><div class=\"pts-hline pts-arr pts-arr-input\"><div class=\"pts-df \" data-pts-infobox=\"id-70d1ae57-7a3e-49ec-8eca-83a95f432766\">DF\n",
+       "        <div id=\"id-70d1ae57-7a3e-49ec-8eca-83a95f432766\" class=\"pts-infobox-item\" data-title=\"DataFrame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>prompt</th>\n",
+       "                    <td></td>\n",
+       "                    <td></td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div>\n",
+       "                    <div class=\"pts-transformer pts-inner \" data-pts-infobox=\"id-5b689a9a-f0e1-4fd8-b643-07e10a85b6f3\">\n",
+       "                        \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-5b689a9a-f0e1-4fd8-b643-07e10a85b6f3\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                <a href=\"https://pyterrier.readthedocs.io/en/latest/ext/pyterrier-rag/backends.html#pyterrier_rag.backend.TextGenerator\" target=\"_blank\" onclick=\"window.event.stopPropagation();\">\n",
+       "                    pyterrier_rag.backend._base.TextGenerator\n",
+       "                </a>\n",
+       "            </div>\n",
+       "            \n",
+       "            <table class=\"pts-df-columns\"><tr><th>input_field</th><td>prompt</td></tr><tr><th>output_field</th><td>qanswer</td></tr><tr><th>logprobs_field</th><td>None</td></tr><tr><th>batch_size</th><td>32</td></tr><tr><th>max_new_tokens</th><td>None</td></tr><tr><th>stop_sequences</th><td>None</td></tr><tr><th>num_responses</th><td>1</td></tr></table>\n",
+       "        </div>\n",
+       "        \n",
+       "                        <div class=\"pts-transformer-title\">TextGenerator</div>\n",
+       "                        <div class=\"pts-inner-schematic pts-inner-labeled\">\n",
+       "                            <div class=\"pts-transformer-title\">backend</div>\n",
+       "                            <div class=\"pts-inner-schematic pts-inner-labeled\"><div class=\"pts-pipeline\"><div class=\"pts-hline pts-arr pts-arr-input\"><div class=\"pts-df \" data-pts-infobox=\"id-17800f47-1e52-472c-a692-83851638a574\">Q\n",
+       "        <div id=\"id-17800f47-1e52-472c-a692-83851638a574\" class=\"pts-infobox-item\" data-title=\"Query Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qid</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td><i>(Query ID)</i> ID of query in frame </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>prompt</th>\n",
+       "                    <td></td>\n",
+       "                    <td></td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div>\n",
+       "                <div class=\"pts-transformer \" data-pts-infobox=\"id-efc22f67-304e-406d-a07b-6619aceac155\">\n",
+       "                    \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-efc22f67-304e-406d-a07b-6619aceac155\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                <a href=\"https://pyterrier.readthedocs.io/en/latest/ext/pyterrier-rag/backends.html#pyterrier_rag.VLLMBackend\" target=\"_blank\" onclick=\"window.event.stopPropagation();\">\n",
+       "                    pyterrier_rag.backend._vllm.VLLMBackend\n",
+       "                </a>\n",
+       "            </div>\n",
+       "            \n",
+       "            \n",
+       "        </div>\n",
+       "        \n",
+       "                    <div class=\"pts-transformer-title\">VLLMBackend</div>\n",
+       "                </div>\n",
+       "                <div class=\"pts-hline pts-arr pts-arr-output\"><div class=\"pts-df \" data-pts-infobox=\"id-1be76c15-aa78-4b0f-885d-17d3071dc531\">A\n",
+       "        <div id=\"id-1be76c15-aa78-4b0f-885d-17d3071dc531\" class=\"pts-infobox-item\" data-title=\"Query Answer Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qid</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td><i>(Query ID)</i> ID of query in frame </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>prompt</th>\n",
+       "                    <td></td>\n",
+       "                    <td></td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"pts-add\">\n",
+       "                    <th>qanswer</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Answer to the query </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div></div></div>\n",
+       "                            </div>\n",
+       "                    </div>\n",
+       "                    <div class=\"pts-hline pts-arr pts-arr-output\"><div class=\"pts-df \" data-pts-infobox=\"id-b8806fd2-d54e-4533-9384-37c68af8cfd6\">A\n",
+       "        <div id=\"id-b8806fd2-d54e-4533-9384-37c68af8cfd6\" class=\"pts-infobox-item\" data-title=\"Query Answer Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>prompt</th>\n",
+       "                    <td></td>\n",
+       "                    <td></td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"pts-add\">\n",
+       "                    <th>qanswer</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Answer to the query </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div></div></div>\n",
+       "                            \n",
+       "                            <div class=\"pts-transformer-title\">prompt</div>\n",
+       "                            <div class=\"pts-inner-schematic pts-inner-labeled\"><div class=\"pts-pipeline\"><div class=\"pts-hline pts-arr pts-arr-input\"><div class=\"pts-df \" data-pts-infobox=\"id-029de4b1-fc5f-41f2-88fd-bf22b513748a\">Q\n",
+       "        <div id=\"id-029de4b1-fc5f-41f2-88fd-bf22b513748a\" class=\"pts-infobox-item\" data-title=\"Query Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qid</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td><i>(Query ID)</i> ID of query in frame </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>query</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Query text </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qcontext</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Context to the query </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div>\n",
+       "                <div class=\"pts-transformer \" data-pts-infobox=\"id-55101859-e5e5-4429-b919-0ba7628e4200\">\n",
+       "                    \n",
+       "        <div class=\"pts-infobox-item\" id=\"id-55101859-e5e5-4429-b919-0ba7628e4200\" data-title=\"Transformer\">\n",
+       "            <div style=\"font-family: monospace; padding: 3px 6px;\">\n",
+       "                \n",
+       "                    __main__.PromptTransformerV2\n",
+       "                \n",
+       "            </div>\n",
+       "            \n",
+       "            \n",
+       "        </div>\n",
+       "        \n",
+       "                    <div class=\"pts-transformer-title\">PromptTransformerV2</div>\n",
+       "                </div>\n",
+       "                <div class=\"pts-hline pts-arr pts-arr-output\"><div class=\"pts-df \" data-pts-infobox=\"id-619ed04c-93ff-404e-b1b7-b27dddae4ff1\">Q\n",
+       "        <div id=\"id-619ed04c-93ff-404e-b1b7-b27dddae4ff1\" class=\"pts-infobox-item\" data-title=\"Query Frame\">\n",
+       "            <table class=\"pts-df-columns\">\n",
+       "                \n",
+       "                <tr class=\"pts-add\">\n",
+       "                    <th>prompt</th>\n",
+       "                    <td></td>\n",
+       "                    <td></td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qid</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td><i>(Query ID)</i> ID of query in frame </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>query</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Query text </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "                <tr class=\"\">\n",
+       "                    <th>qcontext</th>\n",
+       "                    <td><span style=\"font-family: monospace;\">str</span></td>\n",
+       "                    <td>Context to the query </td>\n",
+       "                </tr>\n",
+       "            \n",
+       "            </table>\n",
+       "        </div></div></div></div></div>\n",
+       "                            </div>\n",
+       "                    </div>\n",
+       "                    <div class=\"pts-hline pts-arr pts-arr-output\"><div class=\"pts-df  pts-df-alert\" data-pts-infobox=\"id-bccb4f36-a5f5-4e2e-b1b1-f4578b25b5e2\">?\n",
+       "        <div id=\"id-bccb4f36-a5f5-4e2e-b1b1-f4578b25b5e2\" class=\"pts-infobox-item\" data-title=\"Unknown Frame\">\n",
+       "            <div class=\"pts-infobox-error\">Unknown/incompatible columns</div>\n",
+       "        </div></div></div><div class=\"pts-io-label\">Output</div></div>\n",
+       "        <script>(function () {\n",
+       "    var infobox_stick = null;\n",
+       "    var infobox_source_el = null;\n",
+       "    const infobox_items = {};\n",
+       "    const infobox = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox')[0];\n",
+       "    const infobox_title = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-title')[0];\n",
+       "    const infobox_body = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-body')[0];\n",
+       "    const infobox_hint =  document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-hint')[0];\n",
+       "    const container = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f')[0];\n",
+       "    function replace_infobox(el) {\n",
+       "        if (infobox_source_el !== null) {\n",
+       "            infobox_source_el.classList.remove('pts-infobox-source');\n",
+       "            infobox_source_el = null;\n",
+       "        }\n",
+       "        infobox_body.innerHTML = '';\n",
+       "        const infobox_key = el.dataset.ptsInfobox;\n",
+       "        const infobox_item = infobox_items[infobox_key];\n",
+       "        if (!infobox_item) {\n",
+       "            console.error('ERROR: Infobox item not found for key:', infobox_key);\n",
+       "            return;\n",
+       "        }\n",
+       "        // use camelcase to access dataset attributes with - in the name \n",
+       "        infobox_title.textContent = infobox_item.dataset.title || '';\n",
+       "        infobox.style.display = 'block';\n",
+       "        infobox_body.appendChild(infobox_item);\n",
+       "        if (infobox_body.querySelectorAll('.pts-infobox-error').length > 0) {\n",
+       "            infobox.classList.add('pts-infobox-outer-error');\n",
+       "        } else {\n",
+       "            infobox.classList.remove('pts-infobox-outer-error');\n",
+       "        }\n",
+       "        infobox.scrollTop = 0;\n",
+       "        infobox_body.scrollLeft = 0;\n",
+       "        const infRect = infobox.getBoundingClientRect();\n",
+       "        const contRect = container.getBoundingClientRect();\n",
+       "        const elRect = el.getBoundingClientRect();\n",
+       "        if (elRect.left - contRect.left > infRect.width + 14) {\n",
+       "        // move the infobox to the immediate left/right of this element, depending on where there is space\n",
+       "            infobox.style.left = (elRect.left - contRect.left - infRect.width - 10) + 'px';\n",
+       "        } else {\n",
+       "            infobox.style.left = (elRect.right - contRect.left + 2) + 'px';\n",
+       "        }\n",
+       "        // Move to top of this element (if there is vertical space, otherwise as close as possible)\n",
+       "        var top = elRect.top - contRect.top;\n",
+       "        if (top + infRect.height > contRect.height) {\n",
+       "            top = contRect.height - infRect.height - 4;\n",
+       "        }\n",
+       "        if (top < 0) {\n",
+       "            top = 4;\n",
+       "        }\n",
+       "        infobox.style.top = top + 'px';\n",
+       "        infobox_source_el = el;\n",
+       "        el.classList.add('pts-infobox-source');\n",
+       "    }\n",
+       "    function hide_infobox() {\n",
+       "        if (infobox_source_el !== null) {\n",
+       "            infobox_source_el.classList.remove('pts-infobox-source');\n",
+       "            infobox_source_el = null;\n",
+       "        }\n",
+       "        infobox_stick = null;\n",
+       "        infobox.style.display = 'none';\n",
+       "        infobox.style.opacity = '';\n",
+       "    }\n",
+       "    \n",
+       "    container.addEventListener('click', () => {\n",
+       "        if (infobox_stick) {\n",
+       "            hide_infobox();\n",
+       "        }\n",
+       "    });\n",
+       "    \n",
+       "    const infobox_elements = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f .pts-infobox-item');\n",
+       "    infobox_elements.forEach(el => {\n",
+       "        el.remove();\n",
+       "        el.style.display = 'block';\n",
+       "        infobox_items[el.id] = el;\n",
+       "    });\n",
+       "    \n",
+       "    const data_pts_elements = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f [data-pts-infobox]');\n",
+       "    data_pts_elements.forEach(el => {\n",
+       "        el.addEventListener('mouseenter', () => {\n",
+       "            if (!infobox_stick) {\n",
+       "                replace_infobox(el);\n",
+       "                if (infobox.scrollHeight > infobox.clientHeight || infobox_body.scrollWidth > infobox_body.clientWidth) {\n",
+       "                    infobox_hint.style.display = 'block';\n",
+       "                } else {\n",
+       "                    infobox_hint.style.display = 'none';\n",
+       "                }\n",
+       "            }\n",
+       "        });\n",
+       "        el.addEventListener('mouseleave', () => {\n",
+       "            if (!infobox_stick) {\n",
+       "                hide_infobox();\n",
+       "            }\n",
+       "        });\n",
+       "        el.addEventListener('click', (e) => {\n",
+       "            if (!infobox_stick) {\n",
+       "                infobox_stick = el.dataset.ptsInfobox;\n",
+       "                infobox.style.opacity = 1;\n",
+       "                infobox_stick = el.dataset.ptsInfobox;\n",
+       "                infobox_hint.style.display = 'none';\n",
+       "                replace_infobox(el);\n",
+       "                e.stopPropagation();\n",
+       "            } else if (infobox_stick === el.dataset.ptsInfobox) {\n",
+       "                hide_infobox();\n",
+       "                e.stopPropagation();\n",
+       "            } else {\n",
+       "                infobox_stick = el.dataset.ptsInfobox;\n",
+       "                replace_infobox(el);\n",
+       "                infobox_hint.style.display = 'none';\n",
+       "                e.stopPropagation();\n",
+       "            }\n",
+       "        });\n",
+       "    });\n",
+       "})();\n",
+       "\n",
+       "\n",
+       "(function () {\n",
+       "    // Detect vscode dark mode (not reliably detectable from css directly)\n",
+       "    function getLuminance(hex) {\n",
+       "        const r = parseInt(hex.slice(1, 3), 16);\n",
+       "        const g = parseInt(hex.slice(3, 5), 16);\n",
+       "        const b = parseInt(hex.slice(5, 7), 16);\n",
+       "        const a = [r, g, b].map(function (v) {\n",
+       "            v /= 255;\n",
+       "            return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);\n",
+       "        });\n",
+       "        return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;\n",
+       "    }\n",
+       "    const vscode_background_color = getComputedStyle(document.documentElement).getPropertyValue('--vscode-editor-background');\n",
+       "    const container = document.querySelectorAll('#id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f')[0];\n",
+       "    if (vscode_background_color) {\n",
+       "        document.body.setAttribute('data-vscode', 'true');\n",
+       "        if (getLuminance(vscode_background_color) < 0.5) {\n",
+       "            document.body.setAttribute('theme', 'dark');\n",
+       "        } else {\n",
+       "            document.body.setAttribute('theme', 'light');\n",
+       "        }\n",
+       "    }\n",
+       "})();\n",
+       "\n",
+       "function setNodeState(nodeId, state) {\n",
+       "  const el = document.querySelector(\n",
+       "    `[data-node-id=\"${nodeId}\"]`\n",
+       "  );\n",
+       "  if (!el) {\n",
+       "    console.warn(\"Node not found:\", nodeId);\n",
+       "    return;\n",
+       "  }\n",
+       "\n",
+       "  el.classList.remove(\"pts-pending\", \"pts-running\", \"pts-done\");\n",
+       "  el.classList.add(`pts-${state}`);\n",
+       "}</script>\n",
+       "    </div>\n",
+       "    <div id=\"id-e63420fa-8cfa-4334-a95f-aeda6c5ce72f-pts-rendering-issue\">\n",
+       "        Rendering issue. Try running the cell again.\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "(TctColBert('castorini/tct_colbert-v2-hnp-msmarco').query_encoder() >> JPQ-PQ >> <pyterrier.terrier._text_loader.TerrierTextLoader object at 0x7f86d97534f0> >> <pyterrier_rag.prompt._context_aggregation.Concatenator object at 0x7f85b8a07fd0> >> <pyterrier_rag.readers._base.Reader object at 0x7f85b8a06dd0>)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jpq_rag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0a6f3999-1e13-483f-bc60-771d87fd2c89",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d3916fd6d5724baaa889220b76ea91ef",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>prompt</th>\n",
+       "      <th>qid</th>\n",
+       "      <th>query_0</th>\n",
+       "      <th>qanswer</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;|im_start|&gt;system\\nYou are a helpful assistan...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>who got the first nobel prize in physics</td>\n",
+       "      <td>Wilhelm Röntgen</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                              prompt qid  \\\n",
+       "0  <|im_start|>system\\nYou are a helpful assistan...   1   \n",
+       "\n",
+       "                                    query_0          qanswer  \n",
+       "0  who got the first nobel prize in physics  Wilhelm Röntgen  "
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jpq_rag.search(\"who got the first nobel prize in physics\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "97351877-ed14-4696-891e-386175c47de6",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fb657058958647feb0512cd5c68b1419",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "902b9dd55ae846b785de33fbead4aef5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cb435d49454f4b169b4d80d8649fba8b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b054df9d5df64057b6ac0a01657fbaec",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9fbeb8a483914edca9775bdf573699da",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e1778e9115924a2888968a555debadea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8995153b2a9d4cfab53ffef2c13e46f3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8f62fd7ae4b14f00849628d9298f10fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e538aafe687341af9bf856a6acbeed32",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7ff8593060f54f4fad8bd36517e98fa1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7e912f78981145d69aa89d1440f3a55c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd6ffe7f0f1548d0b2086c6d8a3985df",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b74d19566b924d2b98a31dba23730051",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "31d7ac679d3b473180e8703870149643",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d52af6c08ef4d8a952e42bb3e65b951",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ec9f67c1a864ed9b1a6696454806613",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "512e3eec254846efbdc366cf29f8dcf5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f108ba5e7fec46cc934bf9e3d6aa4f9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e7ae2d895ff44f61942238d1dc36951d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "151c3ed162a3416798f676068cfa76de",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3afff846a0e4241a9ceeba68255210a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b27b8703d81f4cffa4f7492dd156ef01",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "844f99d19156440d888125b83d27c848",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "17780043a468411dac7cc9096b5eb4ba",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "11da6682533f450a9ebdc835ec1b06af",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ecbda4b3a8ed4a40980b44012f648789",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df61608c2c724750a693e5501a2e285c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a57787d08b9f40cbb299fac28fa5712e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "50e8ef49f17a412f9167ce4e7b51a33c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "27a30f4b5a90489f87d1cc9e839c5dfb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d4b1ce57f2934515b7f71e0a60a667b7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b63a6f1051a5477f979b8cfb8d893568",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0027db2c81cf4805928bb47fa95feadc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f5eb5d9ddca741fba942b2f48169a703",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4e06488613da4d7c97e09d6b7ef9b174",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0ac6831e5feb4d47b2f4bb9c18da9292",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "53765ce979e9431b92133d83ed95838c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "68ad503ebeb84a6ca2ffcff6f670d6ce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "463815674ff546ba99ea6243c24fa3c6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4601657f47684207aee508f06d0b4f81",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d347e272d0a845589f0d11fe839ace93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0b299458a59424e8fe8d3126e2a8c3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "160001c6ae674acdadc43eb807a94bd1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5520c6a109a844d69938df856c31e89e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b9a9e572a924624ab06566f391558af",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2adf64a1e80f4f2cb9b5d800013e2194",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e001a200027c42e5b59382e7dc5f1f28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8175ba6d8bc54010b646699c1c1f3ff1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e2dfd3104cf34adbaacebcc796162355",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf48058787fd43989b2299a4acc1ccb1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f0f69182f094bedab6112d2a8d61865",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df7fb4bb34c540699fdfcc616989c607",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb12845e8b284aa7b2ed3c5f14c1bf34",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f8079d024004a91a4a3f4cfa24d20c6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e550d8f8f5674d48b49800ffcdcf694c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c0fefb72750043ed92e1220fcfdf9087",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "acaed4fce50b45f899e84714d5740b3f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "57fca4642ab942e9bccb4d66a925d014",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "32a976e9d9c24effa68796b46aeaad51",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "96c60235e2044d8e9c3f184a2110aa78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a6cea5673684481ac6ac5731a89bb47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9ede52eb8b3940cdb4ed7e1c0b8a9162",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be84acbb7af94afa9b372ee78723842a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "80a9b98a1b0140c68e3ebe68b598d272",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2c4f15dd5ad45c78a59157e06e5c7fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "545e10d9d92c4a968e622e7e65460f0b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "045b7a0a322d4e058a0642fa8e9e3030",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "727aed97cafe4ec08f3f5defcfa0019f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4bec189e817449dab90e78769365df0c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d9ced877b5da4b8ab0fea26452f2c907",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b16ba33f1bef452b842651c4aeff419d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c69772b813b9440c84eeaaad54d64ef7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bbbb99a004e845b1882aea5521b5a4fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26bfc17592cd4601bfbd75b699c7265e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "92316ca0fecd4f259b5ff02b40d31b0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a3057e5b89f42808de5f10407f34a52",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a27d0bf9ec3f4091b4266f13c0292ab6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a281209424943a3a21676aa9bc1e110",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1c73c6634f7a4391a01b4693811269b3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a3ee9203e414fc881ccfb9b55c60489",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25bfbc0dcc6c44bf8d9e6e418bdd0dc5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9c72be980ab84042b36da95b27a5b009",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2df356a3edc4466ab2665b698e61a263",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ec9468552fe649b0836f187ec0d806fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c78d3ada32f6480cadf7e271afdfe873",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9f35eb0e58e54de488796ffbaafd0a53",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2fe394b04533490d8d812d336e25b1e8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f8064d728ab472483d0fa5462f57127",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "19049a727337496f8d58aa2b3a0ed43b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc1f7ec1342f452faa05556834363cdd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "76c4b53df5524cc7bf36aa8989f6aada",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f1b655ae57f43d0bb6f3a4925655d09",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3069a8641cb24dfb92defd43f891e9e4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2db580941df94b16a1d720ee0a984ec2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e6583abac10648efbda0d2ff369fdd2b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7b61342c89b447438ae228c77a9564c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26dd8d097b3d4d24b036cc197dc28b38",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f892e97aa3ba441eac719269acd37958",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3c00ad6574ec4363a68a049df1e54763",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "45c9cf65a00f4edfb3c62b8c7e8c3aed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eabf499e03b44ee894a52f8fe0f46640",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e851d5da5564827be14875a22ba28a3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e4228b57f0d64ed8910ef7560b5edbea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ae6096436f044d9ea267ff0a092bca3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b692f728e0824b6a8c484be0af9b92e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c593994e57194ef5a48af20f93485ba1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ab3ddaa139ce4161a1578318dbe9e0d6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a1d75e871a849e68e8ecfa3905a363a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0110501ffa6845b4a30cf781dc65cdb5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "158913e781b74ee987f75c6261be677d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "695e0d6b99a949bfa4e0f4e6248f3558",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1cc1b1dda8624fd88d6cbd9fc30ad350",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/32 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d6b2abdf59d14d32a89d0221f15587c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Processed prompts:   0%|          | 0/26 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>EM</th>\n",
+       "      <th>F1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TCT-JPQ</td>\n",
+       "      <td>0.263158</td>\n",
+       "      <td>0.399522</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      name        EM        F1\n",
+       "0  TCT-JPQ  0.263158  0.399522"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pt.Experiment(\n",
+    "    [jpq_rag],\n",
+    "    get_topics(\"test\"),\n",
+    "    get_answers(\"test\"),\n",
+    "    [ptr.measures.F1, ptr.measures.EM],\n",
+    "    validate=\"ignore\",\n",
+    "    names=[\"TCT-JPQ\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e3b1654-8625-40a3-b1db-1a7a9b359290",
+   "metadata": {},
+   "source": [
+    "Using TCT JPQ (`topk=5`), `Qwen2.5-3B-Instruct` gets 0.399 F1 and 0.263 EM. \n",
+    "\n",
+    "PS: The default configuration works on a 24 GB GPU. You may adjust the vLLM configuration based on your hardware."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37cc4e5b-2834-4063-919d-74064df83c9f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:pt_jpq]",
+   "language": "python",
+   "name": "conda-env-pt_jpq-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.20"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/jpq-tct-nq.ipynb
+++ b/examples/jpq-tct-nq.ipynb
@@ -35,7 +35,10 @@
    "source": [
     "%%bash\n",
     "\n",
-    "pip install -q transformers==4.57.1 vllm==0.8.* faiss-cpu datasets pyterrier_dr[jpq] pyterrier_rag "
+    "pip install -q transformers==4.57.1 vllm==0.8.* faiss-cpu datasets pyterrier_dr[jpq] pyterrier_rag\n",
+    "\n",
+    "# for Colab\n",
+    "pip uninstall -y tensorflow torchcodec"
    ]
   },
   {
@@ -240,7 +243,9 @@
    "source": [
     "### Prompt & LLM Reader\n",
     "\n",
-    "Here we define a simple prompt and instantiate an LLM reader using [pyterrier_rag](https://github.com/terrierteam/pyterrier_rag/tree/main)."
+    "Here we define a simple prompt and instantiate an LLM reader using [pyterrier_rag](https://github.com/terrierteam/pyterrier_rag/tree/main).\n",
+    "\n",
+    "PS: The default configuration works on an NVIDIA 3090 GPU. You may adjust the vLLM configuration based on your hardware."
    ]
   },
   {
@@ -368,6 +373,9 @@
     "        \"gpu_memory_utilization\": 0.8,\n",
     "        \"max_num_seqs\": 256,\n",
     "        \"max_num_batched_tokens\": 2**16,\n",
+    "        # for older GPUs (e.g. NVIDIA T4)\n",
+    "        # \"max_model_len\": 8192,\n",
+    "        # \"dtype\": \"half\",\n",
     "    },\n",
     "    generation_args={\n",
     "        \"max_tokens\": 32,\n",
@@ -3029,9 +3037,7 @@
    "id": "3e3b1654-8625-40a3-b1db-1a7a9b359290",
    "metadata": {},
    "source": [
-    "Using TCT JPQ (`topk=5`), `Qwen2.5-3B-Instruct` gets 0.399 F1 and 0.263 EM. \n",
-    "\n",
-    "PS: The default configuration works on a 24 GB GPU. You may adjust the vLLM configuration based on your hardware."
+    "Using TCT JPQ (`topk=5`), `Qwen2.5-3B-Instruct` gets 0.399 F1 and 0.263 EM. "
    ]
   },
   {

--- a/examples/jpq-tct-nq.ipynb
+++ b/examples/jpq-tct-nq.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8e718b6a-b7a7-40f7-92bc-ac44d65df585",
+   "metadata": {},
+   "source": [
+    "This notebook provides an example of RAG using JPQ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "78480647-44e5-439a-b80d-d50a6895f70b",
    "metadata": {},
    "source": [


### PR DESCRIPTION
This PR adds a Jupyter notebook (`examples/jpq-tct-nq.ipynb`), which shows how to use JPQ for RAG on NQ.

The notebook links in the README have also been updated.